### PR TITLE
Update codebase to reflect changes to Getting Started guide & generators

### DIFF
--- a/apps/web/application.rb
+++ b/apps/web/application.rb
@@ -13,7 +13,9 @@ module Web
       #
       root __dir__
 
-      # Relative load paths where this application will recursively load the code.
+      # Relative load paths where this application will recursively load the
+      # code.
+      #
       # When you add new directories, remember to add them here.
       #
       load_paths << [
@@ -47,8 +49,10 @@ module Web
       # host 'example.org'
 
       # URI port used by the routing system to generate absolute URLs
-      # Argument: An object coercible to integer, default to 80 if the scheme is http and 443 if it's https
-      # This SHOULD be configured only in case the application listens to that non standard ports
+      # Argument: An object coercible to integer, defaults to 80 if the scheme
+      # is http and 443 if it's https
+      #
+      # This should only be configured if app listens to non-standard ports
       #
       # port 443
 
@@ -56,13 +60,16 @@ module Web
       # Argument: boolean to toggle the feature
       #           A Hash with options
       #
-      # Options: :domain   - The domain (String - nil by default, not required)
-      #          :path     - Restrict cookies to a relative URI (String - nil by default)
-      #          :max_age  - Cookies expiration expressed in seconds (Integer - nil by default)
-      #          :secure   - Restrict cookies to secure connections
-      #                      (Boolean - Automatically set on true if currently using a secure connection)
-      #                      See #scheme and #ssl?
-      #          :httponly - Prevent JavaScript access (Boolean - true by default)
+      # Options:
+      #   :domain   - The domain (String - nil by default, not required)
+      #   :path     - Restrict cookies to a relative URI
+      #               (String - nil by default)
+      #   :max_age  - Cookies expiration expressed in seconds
+      #               (Integer - nil by default)
+      #   :secure   - Restrict cookies to secure connections
+      #               (Boolean - Automatically true when using HTTPS)
+      #               See #scheme and #ssl?
+      #   :httponly - Prevent JavaScript access (Boolean - true by default)
       #
       # cookies true
       # or
@@ -81,26 +88,14 @@ module Web
       # middleware.use Rack::Protection
 
       # Default format for the requests that don't specify an HTTP_ACCEPT header
-      # Argument: A symbol representation of a mime type, default to :html
+      # Argument: A symbol representation of a mime type, defaults to :html
       #
       # default_request_format :html
 
-      # Default format for responses that doesn't take into account the request format
-      # Argument: A symbol representation of a mime type, default to :html
+      # Default format for responses that don't consider the request format
+      # Argument: A symbol representation of a mime type, defaults to :html
       #
       # default_response_format :html
-
-      # HTTP Body parsers
-      # Parse non GET responses body for a specific mime type
-      # Argument: Symbol, which represent the format of the mime type (only `:json` is supported)
-      #           Object, the parser
-      #
-      # body_parsers :json
-
-      # When it's true and the router receives a non-encrypted request (http),
-      # it redirects to the secure equivalent resource (https). Default disabled.
-      #
-      # force_ssl true
 
       ##
       # TEMPLATES
@@ -127,7 +122,7 @@ module Web
         #   * :yui
         #   * :closure
         #
-        # See: http://hanamirb.org/guides/assets/compressors
+        # See: https://guides.hanamirb.org/assets/compressors
         #
         # In order to skip JavaScript compression comment the following line
         javascript_compressor :builtin
@@ -140,7 +135,7 @@ module Web
         #   * :yui
         #   * :sass
         #
-        # See: http://hanamirb.org/guides/assets/compressors
+        # See: https://guides.hanamirb.org/assets/compressors
         #
         # In order to skip stylesheet compression comment the following line
         stylesheet_compressor :builtin
@@ -180,8 +175,8 @@ module Web
       #
       security.x_content_type_options 'nosniff'
 
-      # X-XSS-Protection is a HTTP header to determine the behavior of the browser
-      # in case an XSS attack is detected.
+      # X-XSS-Protection is a HTTP header to determine the behavior of the
+      # browser in case an XSS attack is detected.
       #
       # Read more at:
       #
@@ -190,16 +185,16 @@ module Web
       #
       security.x_xss_protection '1; mode=block'
 
-      # Content-Security-Policy (CSP) is a HTTP header supported by modern browsers.
-      # It determines trusted sources of execution for dynamic contents
-      # (JavaScript) or other web related assets: stylesheets, images, fonts,
-      # plugins, etc.
+      # Content-Security-Policy (CSP) is a HTTP header supported by modern
+      # browsers. It determines trusted sources of execution for dynamic
+      # contents (JavaScript) or other web related assets: stylesheets, images,
+      # fonts, plugins, etc.
       #
       # Web applications can send this header to mitigate Cross Site Scripting
       # (XSS) attacks.
       #
-      # The default value allows images, scripts, AJAX, fonts and CSS from the same
-      # origin, and does not allow any other resources to load (eg object,
+      # The default value allows images, scripts, AJAX, fonts and CSS from the
+      # same origin, and does not allow any other resources to load (eg object,
       # frame, media, etc).
       #
       # Inline JavaScript is NOT allowed. To enable it, please use:
@@ -297,12 +292,12 @@ module Web
 
         # Use fingerprint file name for asset paths
         #
-        # See: http://hanamirb.org/guides/assets/overview
+        # See: https://guides.hanamirb.org/assets/overview
         fingerprint true
 
         # Content Delivery Network (CDN)
         #
-        # See: http://hanamirb.org/guides/assets/content-delivery-network
+        # See: https://guides.hanamirb.org/assets/content-delivery-network
         #
         # scheme 'https'
         # host   'cdn.example.org'
@@ -310,7 +305,7 @@ module Web
 
         # Subresource Integrity
         #
-        # See: http://hanamirb.org/guides/assets/content-delivery-network/#subresource-integrity
+        # See: https://guides.hanamirb.org/assets/content-delivery-network/#subresource-integrity
         subresource_integrity :sha256
       end
     end

--- a/apps/web/controllers/books/create.rb
+++ b/apps/web/controllers/books/create.rb
@@ -4,8 +4,6 @@ module Web
       class Create
         include Web::Action
 
-        expose :book
-
         params do
           required(:book).schema do
             required(:title).filled(:str?)
@@ -15,7 +13,7 @@ module Web
 
         def call(params)
           if params.valid?
-            @book = BookRepository.new.create(params[:book])
+            BookRepository.new.create(params[:book])
 
             redirect_to routes.books_path
           else

--- a/apps/web/controllers/books/create.rb
+++ b/apps/web/controllers/books/create.rb
@@ -1,23 +1,27 @@
-module Web::Controllers::Books
-  class Create
-    include Web::Action
+module Web
+  module Controllers
+    module Books
+      class Create
+        include Web::Action
 
-    expose :book
+        expose :book
 
-    params do
-      required(:book).schema do
-        required(:title).filled(:str?)
-        required(:author).filled(:str?)
-      end
-    end
+        params do
+          required(:book).schema do
+            required(:title).filled(:str?)
+            required(:author).filled(:str?)
+          end
+        end
 
-    def call(params)
-      if params.valid?
-        @book = BookRepository.new.create(params[:book])
+        def call(params)
+          if params.valid?
+            @book = BookRepository.new.create(params[:book])
 
-        redirect_to routes.books_path
-      else
-        self.status = 422
+            redirect_to routes.books_path
+          else
+            self.status = 422
+          end
+        end
       end
     end
   end

--- a/apps/web/controllers/books/index.rb
+++ b/apps/web/controllers/books/index.rb
@@ -1,11 +1,15 @@
-module Web::Controllers::Books
-  class Index
-    include Web::Action
+module Web
+  module Controllers
+    module Books
+      class Index
+        include Web::Action
 
-    expose :books
+        expose :books
 
-    def call(params)
-      @books = BookRepository.new.all
+        def call(params)
+          @books = BookRepository.new.all
+        end
+      end
     end
   end
 end

--- a/apps/web/controllers/books/new.rb
+++ b/apps/web/controllers/books/new.rb
@@ -1,8 +1,12 @@
-module Web::Controllers::Books
-  class New
-    include Web::Action
+module Web
+  module Controllers
+    module Books
+      class New
+        include Web::Action
 
-    def call(params)
+        def call(params)
+        end
+      end
     end
   end
 end

--- a/apps/web/controllers/home/index.rb
+++ b/apps/web/controllers/home/index.rb
@@ -1,8 +1,12 @@
-module Web::Controllers::Home
-  class Index
-    include Web::Action
+module Web
+  module Controllers
+    module Home
+      class Index
+        include Web::Action
 
-    def call(params)
+        def call(params)
+        end
+      end
     end
   end
 end

--- a/apps/web/templates/application.html.erb
+++ b/apps/web/templates/application.html.erb
@@ -1,7 +1,8 @@
 <!DOCTYPE HTML>
 <html>
   <head>
-    <title>Bookshelf</title>
+    <title>Web</title>
+    <%= favicon %>
   </head>
   <body>
     <h1>Bookshelf</h1>

--- a/apps/web/templates/application.html.erb
+++ b/apps/web/templates/application.html.erb
@@ -1,4 +1,4 @@
-<!DOCTYPE HTML>
+<!DOCTYPE html>
 <html>
   <head>
     <title>Web</title>

--- a/apps/web/templates/books/index.html.erb
+++ b/apps/web/templates/books/index.html.erb
@@ -12,3 +12,4 @@
 <% else %>
   <p class="placeholder">There are no books yet.</p>
 <% end %>
+<a href="<%= routes.new_book_path %>">New book</a>

--- a/apps/web/views/books/create.rb
+++ b/apps/web/views/books/create.rb
@@ -1,6 +1,10 @@
-module Web::Views::Books
-  class Create
-    include Web::View
-    template 'books/new'
+module Web
+  module Views
+    module Books
+      class Create
+        include Web::View
+        template 'books/new'
+      end
+    end
   end
 end

--- a/apps/web/views/books/index.rb
+++ b/apps/web/views/books/index.rb
@@ -1,5 +1,9 @@
-module Web::Views::Books
-  class Index
-    include Web::View
+module Web
+  module Views
+    module Books
+      class Index
+        include Web::View
+      end
+    end
   end
 end

--- a/apps/web/views/books/new.rb
+++ b/apps/web/views/books/new.rb
@@ -1,5 +1,9 @@
-module Web::Views::Books
-  class New
-    include Web::View
+module Web
+  module Views
+    module Books
+      class New
+        include Web::View
+      end
+    end
   end
 end

--- a/apps/web/views/home/index.rb
+++ b/apps/web/views/home/index.rb
@@ -1,5 +1,9 @@
-module Web::Views::Home
-  class Index
-    include Web::View
+module Web
+  module Views
+    module Home
+      class Index
+        include Web::View
+      end
+    end
   end
 end

--- a/config.ru
+++ b/config.ru
@@ -1,3 +1,3 @@
-require './config/environment'
+require_relative 'config/environment'
 
 run Hanami.app

--- a/config/environment.rb
+++ b/config/environment.rb
@@ -18,7 +18,7 @@ Hanami.configure do
     #    adapter :sql, 'postgres://localhost/bookshelf_development'
     #    adapter :sql, 'mysql://localhost/bookshelf_development'
     #
-    adapter :sql, ENV['DATABASE_URL']
+    adapter :sql, ENV.fetch('DATABASE_URL')
 
     ##
     # Migrations
@@ -43,7 +43,7 @@ Hanami.configure do
     logger level: :info, formatter: :json
 
     mailer do
-      delivery :smtp, address: ENV['SMTP_HOST'], port: ENV['SMTP_PORT']
+      delivery :smtp, address: ENV.fetch('SMTP_HOST'), port: ENV.fetch('SMTP_PORT')
     end
   end
 end

--- a/config/environment.rb
+++ b/config/environment.rb
@@ -30,12 +30,12 @@ Hanami.configure do
   mailer do
     root 'lib/bookshelf/mailers'
 
-    # See http://hanamirb.org/guides/mailers/delivery
+    # See https://guides.hanamirb.org/mailers/delivery
     delivery :test
   end
 
   environment :development do
-    # See: http://hanamirb.org/guides/projects/logging
+    # See: https://guides.hanamirb.org/projects/logging
     logger level: :debug
   end
 

--- a/config/environment.rb
+++ b/config/environment.rb
@@ -40,7 +40,7 @@ Hanami.configure do
   end
 
   environment :production do
-    logger level: :info, formatter: :json
+    logger level: :info, formatter: :json, filter: []
 
     mailer do
       delivery :smtp, address: ENV.fetch('SMTP_HOST'), port: ENV.fetch('SMTP_PORT')

--- a/spec/web/controllers/books/create_spec.rb
+++ b/spec/web/controllers/books/create_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe Web::Controllers::Books::Create do
   end
 
   describe 'with valid params' do
-    let(:params) { Hash[book: { title: '1984', author: 'George Orwell' }] }
+    let(:params) { Hash[book: { title: 'Confident Ruby', author: 'Avdi Grimm' }] }
 
     it 'creates a new book' do
       action.call(params)
@@ -28,12 +28,12 @@ RSpec.describe Web::Controllers::Books::Create do
   describe 'with invalid params' do
     let(:params) { Hash[book: {}] }
 
-    it 're-renders the books#new view' do
+    it 'returns HTTP client error' do
       response = action.call(params)
       expect(response[0]).to eq(422)
     end
 
-    it 'sets errors attribute accordingly' do
+    it 'dumps errors in params' do
       action.call(params)
       errors = action.params.errors
 

--- a/spec/web/controllers/books/create_spec.rb
+++ b/spec/web/controllers/books/create_spec.rb
@@ -1,4 +1,4 @@
-RSpec.describe Web::Controllers::Books::Create do
+RSpec.describe Web::Controllers::Books::Create, type: :action do
   let(:action) { described_class.new }
   let(:repository) { BookRepository.new }
 

--- a/spec/web/controllers/books/create_spec.rb
+++ b/spec/web/controllers/books/create_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 require_relative '../../../../apps/web/controllers/books/create'
 
-describe Web::Controllers::Books::Create do
+RSpec.describe Web::Controllers::Books::Create do
   let(:action) { Web::Controllers::Books::Create.new }
   let(:repository) { BookRepository.new }
 

--- a/spec/web/controllers/books/create_spec.rb
+++ b/spec/web/controllers/books/create_spec.rb
@@ -2,7 +2,7 @@ RSpec.describe Web::Controllers::Books::Create, type: :action do
   let(:action) { described_class.new }
   let(:repository) { BookRepository.new }
 
-  after do
+  before do
     repository.clear
   end
 

--- a/spec/web/controllers/books/create_spec.rb
+++ b/spec/web/controllers/books/create_spec.rb
@@ -2,7 +2,7 @@ require 'spec_helper'
 require_relative '../../../../apps/web/controllers/books/create'
 
 RSpec.describe Web::Controllers::Books::Create do
-  let(:action) { Web::Controllers::Books::Create.new }
+  let(:action) { described_class.new }
   let(:repository) { BookRepository.new }
 
   after do

--- a/spec/web/controllers/books/create_spec.rb
+++ b/spec/web/controllers/books/create_spec.rb
@@ -1,6 +1,3 @@
-require 'spec_helper'
-require_relative '../../../../apps/web/controllers/books/create'
-
 RSpec.describe Web::Controllers::Books::Create do
   let(:action) { described_class.new }
   let(:repository) { BookRepository.new }

--- a/spec/web/controllers/books/create_spec.rb
+++ b/spec/web/controllers/books/create_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe Web::Controllers::Books::Create, type: :action do
     repository.clear
   end
 
-  describe 'with valid params' do
+  context 'with valid params' do
     let(:params) { Hash[book: { title: 'Confident Ruby', author: 'Avdi Grimm' }] }
 
     it 'creates a new book' do
@@ -25,7 +25,7 @@ RSpec.describe Web::Controllers::Books::Create, type: :action do
     end
   end
 
-  describe 'with invalid params' do
+  context 'with invalid params' do
     let(:params) { Hash[book: {}] }
 
     it 'returns HTTP client error' do

--- a/spec/web/controllers/books/index_spec.rb
+++ b/spec/web/controllers/books/index_spec.rb
@@ -2,7 +2,7 @@ require 'spec_helper'
 require_relative '../../../../apps/web/controllers/books/index'
 
 RSpec.describe Web::Controllers::Books::Index do
-  let(:action) { Web::Controllers::Books::Index.new }
+  let(:action) { described_class.new }
   let(:params) { Hash[] }
 
   it 'is successful' do

--- a/spec/web/controllers/books/index_spec.rb
+++ b/spec/web/controllers/books/index_spec.rb
@@ -1,6 +1,3 @@
-require 'spec_helper'
-require_relative '../../../../apps/web/controllers/books/index'
-
 RSpec.describe Web::Controllers::Books::Index do
   let(:action) { described_class.new }
   let(:params) { Hash[] }

--- a/spec/web/controllers/books/index_spec.rb
+++ b/spec/web/controllers/books/index_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 require_relative '../../../../apps/web/controllers/books/index'
 
-describe Web::Controllers::Books::Index do
+RSpec.describe Web::Controllers::Books::Index do
   let(:action) { Web::Controllers::Books::Index.new }
   let(:params) { Hash[] }
 

--- a/spec/web/controllers/books/index_spec.rb
+++ b/spec/web/controllers/books/index_spec.rb
@@ -1,9 +1,21 @@
 RSpec.describe Web::Controllers::Books::Index, type: :action do
   let(:action) { described_class.new }
   let(:params) { Hash[] }
+  let(:repository) { BookRepository.new }
+
+  before do
+    repository.clear
+
+    @book = repository.create(title: 'TDD', author: 'Kent Beck')
+  end
 
   it 'is successful' do
     response = action.call(params)
     expect(response[0]).to eq(200)
+  end
+
+  it 'exposes all books' do
+    action.call(params)
+    expect(action.exposures[:books]).to eq([@book])
   end
 end

--- a/spec/web/controllers/books/index_spec.rb
+++ b/spec/web/controllers/books/index_spec.rb
@@ -1,4 +1,4 @@
-RSpec.describe Web::Controllers::Books::Index do
+RSpec.describe Web::Controllers::Books::Index, type: :action do
   let(:action) { described_class.new }
   let(:params) { Hash[] }
 

--- a/spec/web/controllers/books/new_spec.rb
+++ b/spec/web/controllers/books/new_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 require_relative '../../../../apps/web/controllers/books/new'
 
-describe Web::Controllers::Books::New do
+RSpec.describe Web::Controllers::Books::New do
   let(:action) { Web::Controllers::Books::New.new }
   let(:params) { Hash[] }
 

--- a/spec/web/controllers/books/new_spec.rb
+++ b/spec/web/controllers/books/new_spec.rb
@@ -1,4 +1,4 @@
-RSpec.describe Web::Controllers::Books::New do
+RSpec.describe Web::Controllers::Books::New, type: :action do
   let(:action) { described_class.new }
   let(:params) { Hash[] }
 

--- a/spec/web/controllers/books/new_spec.rb
+++ b/spec/web/controllers/books/new_spec.rb
@@ -2,7 +2,7 @@ require 'spec_helper'
 require_relative '../../../../apps/web/controllers/books/new'
 
 RSpec.describe Web::Controllers::Books::New do
-  let(:action) { Web::Controllers::Books::New.new }
+  let(:action) { described_class.new }
   let(:params) { Hash[] }
 
   it 'is successful' do

--- a/spec/web/controllers/books/new_spec.rb
+++ b/spec/web/controllers/books/new_spec.rb
@@ -1,6 +1,3 @@
-require 'spec_helper'
-require_relative '../../../../apps/web/controllers/books/new'
-
 RSpec.describe Web::Controllers::Books::New do
   let(:action) { described_class.new }
   let(:params) { Hash[] }

--- a/spec/web/features/add_book_spec.rb
+++ b/spec/web/features/add_book_spec.rb
@@ -1,7 +1,7 @@
 require 'features_helper'
 
 RSpec.describe 'Add a book' do
-  after do
+  before do
     BookRepository.new.clear
   end
 

--- a/spec/web/features/add_book_spec.rb
+++ b/spec/web/features/add_book_spec.rb
@@ -1,6 +1,6 @@
 require 'features_helper'
 
-describe 'Add a book' do
+RSpec.describe 'Add a book' do
   after do
     BookRepository.new.clear
   end

--- a/spec/web/features/list_books_spec.rb
+++ b/spec/web/features/list_books_spec.rb
@@ -1,6 +1,6 @@
 require 'features_helper'
 
-describe 'List books' do
+RSpec.describe 'List books' do
   let(:repository) { BookRepository.new }
   before do
     repository.clear

--- a/spec/web/features/list_books_spec.rb
+++ b/spec/web/features/list_books_spec.rb
@@ -5,15 +5,16 @@ RSpec.describe 'List books' do
   before do
     repository.clear
 
-    repository.create(title: 'PoEAA', author: 'Martin Fowler')
-    repository.create(title: 'TDD',   author: 'Kent Beck')
+    repository.create(title: 'Practical Object-Oriented Design in Ruby', author: 'Sandi Metz')
   end
 
   it 'displays each book on the page' do
     visit '/books'
 
     within '#books' do
-      expect(page).to have_css('.book', count: 2)
+      expect(page).to have_selector('.book', count: 1), 'Expected to find 1 book'
+      expect(page).to have_content('Practical Object-Oriented Design in Ruby')
+      expect(page).to have_content('Sandi Metz')
     end
   end
 end

--- a/spec/web/features/visit_home_spec.rb
+++ b/spec/web/features/visit_home_spec.rb
@@ -1,6 +1,6 @@
 require 'features_helper'
 
-describe 'Visit home' do
+RSpec.describe 'Visit home' do
   it 'is successful' do
     visit '/'
 

--- a/spec/web/views/books/create_spec.rb
+++ b/spec/web/views/books/create_spec.rb
@@ -4,7 +4,7 @@ require_relative '../../../../apps/web/views/books/create'
 RSpec.describe Web::Views::Books::Create do
   let(:exposures) { Hash[foo: 'bar'] }
   let(:template)  { Hanami::View::Template.new('apps/web/templates/books/create.html.erb') }
-  let(:view)      { Web::Views::Books::Create.new(template, exposures) }
+  let(:view)      { described_class.new(template, exposures) }
   let(:rendered)  { view.render }
 
   it 'exposes #foo' do

--- a/spec/web/views/books/create_spec.rb
+++ b/spec/web/views/books/create_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 require_relative '../../../../apps/web/views/books/create'
 
-describe Web::Views::Books::Create do
+RSpec.describe Web::Views::Books::Create do
   let(:exposures) { Hash[foo: 'bar'] }
   let(:template)  { Hanami::View::Template.new('apps/web/templates/books/create.html.erb') }
   let(:view)      { Web::Views::Books::Create.new(template, exposures) }

--- a/spec/web/views/books/create_spec.rb
+++ b/spec/web/views/books/create_spec.rb
@@ -1,6 +1,3 @@
-require 'spec_helper'
-require_relative '../../../../apps/web/views/books/create'
-
 RSpec.describe Web::Views::Books::Create do
   let(:exposures) { Hash[foo: 'bar'] }
   let(:template)  { Hanami::View::Template.new('apps/web/templates/books/create.html.erb') }

--- a/spec/web/views/books/create_spec.rb
+++ b/spec/web/views/books/create_spec.rb
@@ -1,4 +1,4 @@
-RSpec.describe Web::Views::Books::Create do
+RSpec.describe Web::Views::Books::Create, type: :view do
   let(:exposures) { Hash[foo: 'bar'] }
   let(:template)  { Hanami::View::Template.new('apps/web/templates/books/create.html.erb') }
   let(:view)      { described_class.new(template, exposures) }

--- a/spec/web/views/books/create_spec.rb
+++ b/spec/web/views/books/create_spec.rb
@@ -1,13 +1,10 @@
 RSpec.describe Web::Views::Books::Create, type: :view do
-  let(:exposures) { Hash[foo: 'bar'] }
+  let(:exposures) { Hash[format: :html] }
   let(:template)  { Hanami::View::Template.new('apps/web/templates/books/create.html.erb') }
   let(:view)      { described_class.new(template, exposures) }
   let(:rendered)  { view.render }
 
-  it 'exposes #foo' do
-    skip 'This is an auto-generated test. Edit it and add your own tests.'
-
-    # Example
-    view.foo.must_equal exposures.fetch(:foo)
+  it 'exposes #format' do
+    expect(view.format).to eq exposures.fetch(:format)
   end
 end

--- a/spec/web/views/books/index_spec.rb
+++ b/spec/web/views/books/index_spec.rb
@@ -1,4 +1,4 @@
-RSpec.describe Web::Views::Books::Index do
+RSpec.describe Web::Views::Books::Index, type: :view do
   let(:exposures) { Hash[books: []] }
   let(:template)  { Hanami::View::Template.new('apps/web/templates/books/index.html.erb') }
   let(:view)      { described_class.new(template, exposures) }

--- a/spec/web/views/books/index_spec.rb
+++ b/spec/web/views/books/index_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 require_relative '../../../../apps/web/views/books/index'
 
-describe Web::Views::Books::Index do
+RSpec.describe Web::Views::Books::Index do
   let(:exposures) { Hash[books: []] }
   let(:template)  { Hanami::View::Template.new('apps/web/templates/books/index.html.erb') }
   let(:view)      { Web::Views::Books::Index.new(template, exposures) }

--- a/spec/web/views/books/index_spec.rb
+++ b/spec/web/views/books/index_spec.rb
@@ -8,13 +8,13 @@ RSpec.describe Web::Views::Books::Index, type: :view do
     expect(view.books).to eq(exposures.fetch(:books))
   end
 
-  describe 'when there are no books' do
+  context 'when there are no books' do
     it 'shows a placeholder message' do
       expect(rendered).to include('<p class="placeholder">There are no books yet.</p>')
     end
   end
 
-  describe 'when there are books' do
+  context 'when there are books' do
     let(:book1)     { Book.new(title: 'Refactoring', author: 'Martin Fowler') }
     let(:book2)     { Book.new(title: 'Domain Driven Design', author: 'Eric Evans') }
     let(:exposures) { Hash[books: [book1, book2]] }

--- a/spec/web/views/books/index_spec.rb
+++ b/spec/web/views/books/index_spec.rb
@@ -1,6 +1,3 @@
-require 'spec_helper'
-require_relative '../../../../apps/web/views/books/index'
-
 RSpec.describe Web::Views::Books::Index do
   let(:exposures) { Hash[books: []] }
   let(:template)  { Hanami::View::Template.new('apps/web/templates/books/index.html.erb') }

--- a/spec/web/views/books/index_spec.rb
+++ b/spec/web/views/books/index_spec.rb
@@ -4,7 +4,7 @@ require_relative '../../../../apps/web/views/books/index'
 RSpec.describe Web::Views::Books::Index do
   let(:exposures) { Hash[books: []] }
   let(:template)  { Hanami::View::Template.new('apps/web/templates/books/index.html.erb') }
-  let(:view)      { Web::Views::Books::Index.new(template, exposures) }
+  let(:view)      { described_class.new(template, exposures) }
   let(:rendered)  { view.render }
 
   it 'exposes #books' do

--- a/spec/web/views/books/new_spec.rb
+++ b/spec/web/views/books/new_spec.rb
@@ -1,4 +1,4 @@
-RSpec.describe Web::Views::Books::New do
+RSpec.describe Web::Views::Books::New, type: :view do
   let(:params)    { OpenStruct.new(valid?: false, error_messages: ['Title must be filled', 'Author must be filled']) }
   let(:exposures) { Hash[params: params] }
   let(:template)  { Hanami::View::Template.new('apps/web/templates/books/new.html.erb') }

--- a/spec/web/views/books/new_spec.rb
+++ b/spec/web/views/books/new_spec.rb
@@ -1,15 +1,3 @@
-require 'spec_helper'
-require_relative '../../../../apps/web/views/books/new'
-
-class NewBookParams < Hanami::Action::Params
-  params do
-    required(:book).schema do
-      required(:title).filled(:str?)
-      required(:author).filled(:str?)
-    end
-  end
-end
-
 RSpec.describe Web::Views::Books::New do
   let(:params)    { OpenStruct.new(valid?: false, error_messages: ['Title must be filled', 'Author must be filled']) }
   let(:exposures) { Hash[params: params] }
@@ -18,11 +6,8 @@ RSpec.describe Web::Views::Books::New do
   let(:rendered)  { view.render }
 
   it 'displays list of errors when params contains errors' do
-    params.valid? # trigger validations
-
     expect(rendered).to include('There was a problem with your submission')
     expect(rendered).to include('Title must be filled')
     expect(rendered).to include('Author must be filled')
   end
 end
-

--- a/spec/web/views/books/new_spec.rb
+++ b/spec/web/views/books/new_spec.rb
@@ -10,7 +10,7 @@ class NewBookParams < Hanami::Action::Params
   end
 end
 
-describe Web::Views::Books::New do
+RSpec.describe Web::Views::Books::New do
   let(:params)    { OpenStruct.new(valid?: false, error_messages: ['Title must be filled', 'Author must be filled']) }
   let(:exposures) { Hash[params: params] }
   let(:template)  { Hanami::View::Template.new('apps/web/templates/books/new.html.erb') }

--- a/spec/web/views/books/new_spec.rb
+++ b/spec/web/views/books/new_spec.rb
@@ -2,7 +2,7 @@ RSpec.describe Web::Views::Books::New do
   let(:params)    { OpenStruct.new(valid?: false, error_messages: ['Title must be filled', 'Author must be filled']) }
   let(:exposures) { Hash[params: params] }
   let(:template)  { Hanami::View::Template.new('apps/web/templates/books/new.html.erb') }
-  let(:view)      { Web::Views::Books::New.new(template, exposures) }
+  let(:view)      { described_class.new(template, exposures) }
   let(:rendered)  { view.render }
 
   it 'displays list of errors when params contains errors' do


### PR DESCRIPTION
This repo was created in Dec 2016 and it's only been occasionally updated to reflect changes in the Getting Started Guide.

I just went through it again (https://github.com/hanami/guides/pull/93) and then `diff`ed the folders. 

This should make them in perfect parity now again. (The last two commit are assuming hanami/guides#93 gets merged).

I (rather painstakingly) went through and tracked where each change came from, and linked to the PR/commit as applicable. I hope that's helpful to someone at some point (but it might not be).